### PR TITLE
errorhandler & wallet system  add

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -24,17 +24,25 @@ repositories {
 }
 
 dependencies {
+    // 스프링 부트 스타터 의존성
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-web")
     compileOnly("org.projectlombok:lombok")
     developmentOnly("org.springframework.boot:spring-boot-devtools")
+    
+    // 데이터베이스 연동
     runtimeOnly("com.h2database:h2")
+    
+    // 롬복
     annotationProcessor("org.projectlombok:lombok")
+    
+    // 테스트 관련 의존성
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.security:spring-security-test")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testImplementation("org.springframework.boot:spring-boot-test-autoconfigure")
 }
 
 tasks.withType<Test> {

--- a/backend/src/main/java/com/back/back9/domain/wallet/controller/WalletController.java
+++ b/backend/src/main/java/com/back/back9/domain/wallet/controller/WalletController.java
@@ -1,0 +1,46 @@
+package com.back.back9.domain.wallet.controller;
+
+import com.back.back9.domain.wallet.dto.ChargePointsRequest;
+import com.back.back9.domain.wallet.dto.WalletBalanceResponse;
+import com.back.back9.domain.wallet.service.WalletService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/wallets")
+@RequiredArgsConstructor
+@Validated
+@Slf4j
+public class WalletController {
+
+    private final WalletService walletService;
+
+    // 지갑 잔액 조회(GET 요청)
+    @GetMapping("/users/{userId}/coins/{coinId}")
+    public ResponseEntity<WalletBalanceResponse> getWalletBalance(
+            @PathVariable int userId,
+            @PathVariable int coinId) {
+
+        log.info("지갑 잔액 조회 요청 - 사용자 ID: {}, 코인 ID: {}", userId, coinId);
+        return walletService.getWalletBalance(userId, coinId);
+    }
+
+    // 포인트 충전(POST 요청)
+    @PostMapping("/users/{userId}/coins/{coinId}/charge")
+    public ResponseEntity<WalletBalanceResponse> chargePoints(
+            @PathVariable int userId,
+            @PathVariable int coinId,
+            @Valid @RequestBody ChargePointsRequest request) {
+
+        log.info("포인트 충전 요청 - 사용자 ID: {}, 코인 ID: {}, 충전 금액: {}",
+                userId, coinId, request.getAmount());
+
+        return walletService.chargePoints(userId, coinId, request);
+    }
+
+
+}

--- a/backend/src/main/java/com/back/back9/domain/wallet/dto/ChargePointsRequest.java
+++ b/backend/src/main/java/com/back/back9/domain/wallet/dto/ChargePointsRequest.java
@@ -1,0 +1,22 @@
+package com.back.back9.domain.wallet.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+import java.math.BigDecimal;
+
+
+// 충전 포인트 요청 DTO
+public record ChargePointsRequest(
+        @NotNull(message = "충전할 포인트는 필수입니다")
+        @Positive(message = "충전할 포인트는 양수여야 합니다")
+        BigDecimal amount
+) {
+    public ChargePointsRequest(BigDecimal amount) {
+        this.amount = amount;
+    }
+    public BigDecimal getAmount() {
+        return amount;
+    }
+
+}

--- a/backend/src/main/java/com/back/back9/domain/wallet/dto/WalletBalanceResponse.java
+++ b/backend/src/main/java/com/back/back9/domain/wallet/dto/WalletBalanceResponse.java
@@ -1,0 +1,34 @@
+package com.back.back9.domain.wallet.dto;
+
+import com.back.back9.domain.wallet.entity.Wallet;
+
+import java.math.BigDecimal;
+// 지갑 잔액 응답 DTO
+public record  WalletBalanceResponse (
+        int walletId,
+        int userId,
+        String address,
+        BigDecimal balance
+) {
+    public WalletBalanceResponse(int walletId, int userId, String address, BigDecimal balance) {
+        this.walletId = walletId;
+        this.userId = userId;
+        this.address = address;
+        this.balance = balance;
+    }
+
+    // 정적 팩토리 메서드
+    public WalletBalanceResponse of(int walletId, int userId, String address, BigDecimal balance) {
+        return new WalletBalanceResponse(walletId, userId, address, balance);
+    }
+    // Wallet 엔티티를 WalletBalanceResponse로 변환하는 정적 팩토리 메서드
+    public static WalletBalanceResponse from(Wallet wallet){
+        return new WalletBalanceResponse(
+                wallet.getId(),
+                wallet.getUserId(),
+                wallet.getAddress(),
+                wallet.getBalance()
+        );
+    }
+
+}

--- a/backend/src/main/java/com/back/back9/domain/wallet/entity/Wallet.java
+++ b/backend/src/main/java/com/back/back9/domain/wallet/entity/Wallet.java
@@ -1,0 +1,53 @@
+package com.back.back9.domain.wallet.entity;
+
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+
+// Wallet 엔티티
+// 이 클래스는 사용자의 지갑 정보를 나타내며, 잔액 충전 기능을 포함합니다.
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "wallet")
+public class Wallet {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    @NotNull
+    @Column(name = "user_id")
+    private int userId;
+
+    @NotNull
+    @Column(name = "coin_id")
+    private int coinId;
+
+    @NotNull
+    private String address;
+
+    // 기본 잔액을 5억으로 설정
+    @Builder.Default
+    @Column(precision = 19, scale = 8)
+    private BigDecimal balance = BigDecimal.valueOf(500000000);
+
+    @Builder.Default
+    @Column(name = "created_at")
+    private OffsetDateTime createdAt = OffsetDateTime.now();
+
+    @Column(name = "updated_at")
+    private OffsetDateTime updatedAt;
+
+    // 비즈니스 메서드
+    public void charge(BigDecimal amount) {
+        this.balance = this.balance.add(amount);
+        this.updatedAt = OffsetDateTime.now();
+    }
+
+}

--- a/backend/src/main/java/com/back/back9/domain/wallet/repository/WalletRepository.java
+++ b/backend/src/main/java/com/back/back9/domain/wallet/repository/WalletRepository.java
@@ -1,0 +1,17 @@
+package com.back.back9.domain.wallet.repository;
+
+import com.back.back9.domain.wallet.entity.Wallet;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface WalletRepository extends JpaRepository<Wallet, Integer> {
+
+    Optional<Wallet> findByUserIdAndCoinId(int userId, int coinId);
+
+    List<Wallet> findByUserId(int userId);
+
+}

--- a/backend/src/main/java/com/back/back9/domain/wallet/service/WalletService.java
+++ b/backend/src/main/java/com/back/back9/domain/wallet/service/WalletService.java
@@ -1,0 +1,75 @@
+package com.back.back9.domain.wallet.service;
+
+import com.back.back9.domain.wallet.dto.ChargePointsRequest;
+import com.back.back9.domain.wallet.dto.WalletBalanceResponse;
+import com.back.back9.domain.wallet.entity.Wallet;
+import com.back.back9.domain.wallet.repository.WalletRepository;
+import com.back.back9.global.error.ErrorCode;
+import com.back.back9.global.error.ErrorException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+
+@Service
+@RequiredArgsConstructor
+
+@Slf4j
+public class WalletService {
+
+    private final WalletRepository walletRepository;
+
+    // 지갑 잔액 조회
+    @Transactional(readOnly = true)
+    public ResponseEntity<WalletBalanceResponse> getWalletBalance(int userId, int coinId) {
+
+        // 저장소에서 사용자 ID와 코인 ID로 지갑 조회
+        // 에러 발생 시 ErrorException(ErrorCode.WALLET_NOT_FOUND) 예외 발생
+        Wallet wallet = walletRepository.findByUserIdAndCoinId(userId, coinId)
+                .orElseThrow(() -> new ErrorException(ErrorCode.WALLET_NOT_FOUND, userId, coinId));
+
+        // 지갑 잔액 조회 성공 시 WalletBalanceResponse 객체 생성
+        WalletBalanceResponse response = WalletBalanceResponse.from(wallet);
+
+        // 로그 기록
+        log.info("지갑 잔액 조회 완료 - 사용자 ID: {}, 코인 ID: {}, 잔액: {}",
+                userId, coinId, wallet.getBalance());
+        return ResponseEntity.ok(response);
+    }
+
+    // 포인트 충전
+    @Transactional
+    public ResponseEntity<WalletBalanceResponse> chargePoints(int userId, int coinId, ChargePointsRequest request) {
+
+        // 사용자 ID와 코인 ID로 지갑 조회
+        // 에러 발생 시 ErrorException(ErrorCode.WALLET_NOT_FOUND) 예외 발생
+        Wallet wallet = walletRepository.findByUserIdAndCoinId(userId, coinId)
+                .orElseThrow(() -> new ErrorException(ErrorCode.WALLET_NOT_FOUND, userId, coinId));
+
+        // 충전 금액이 0 이하인 경우 에러 발생
+        if(request.getAmount().compareTo(BigDecimal.ZERO) <= 0) {
+            throw new ErrorException(ErrorCode.INVALID_REQUEST, "충전 금액은 0보다 커야 합니다.");
+        }
+
+        // 충전 금액을 지갑 잔액에 추가
+        wallet.charge(request.getAmount());
+
+
+        // 지갑 정보를 저장
+        walletRepository.save(wallet);
+
+        // 충전 완료 후 로그 기록
+        log.info("포인트 충전 완료 - 사용자 ID: {}, 충전 금액: {}, 잔액: {}",
+                userId, request.getAmount(), wallet.getBalance());
+
+
+        // WalletBalanceResponse 객체 생성 후 반환
+        WalletBalanceResponse response = WalletBalanceResponse.from(wallet);
+        return ResponseEntity.ok(response);
+    }
+
+
+}

--- a/backend/src/main/java/com/back/back9/global/error/ErrorCode.java
+++ b/backend/src/main/java/com/back/back9/global/error/ErrorCode.java
@@ -1,0 +1,34 @@
+package com.back.back9.global.error;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode {
+    // 400
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "400-INVALID-REQUEST", "잘못된 요청입니다."),
+
+    // 401
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "401-UNAUTHORIZED", "인증이 필요합니다."),
+    // 403
+    FORBIDDEN(HttpStatus.FORBIDDEN, "403-FORBIDDEN", "접근 권한이 없습니다."),
+    // 404
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "404-USER-NOT-FOUND", "사용자를 찾을 수 없습니다. id=%s"),
+    WALLET_NOT_FOUND(HttpStatus.NOT_FOUND, "404-WALLET-NOT-FOUND", "지갑을 찾을 수 없습니다. id=%s"),
+    COIN_NOT_FOUND(HttpStatus.NOT_FOUND, "404-COIN-NOT-FOUND", "코인을 찾을 수 없습니다. id=%s"),
+    // 409
+    DUPLICATED_EMAIL(HttpStatus.CONFLICT, "409-DUPLICATED-EMAIL", "이미 존재하는 이메일입니다. email=%s"),
+    // 500
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "500-INTERNAL-ERROR", "서버 내부 오류입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String defaultDetail; // detail 포맷(가변 인자 치환용)
+
+    ErrorCode(HttpStatus status, String code, String defaultDetail) {
+        this.status = status;
+        this.code = code;
+        this.defaultDetail = defaultDetail;
+    }
+
+}

--- a/backend/src/main/java/com/back/back9/global/error/ErrorException.java
+++ b/backend/src/main/java/com/back/back9/global/error/ErrorException.java
@@ -1,0 +1,16 @@
+package com.back.back9.global.error;
+
+import lombok.Getter;
+
+@Getter
+public class ErrorException extends RuntimeException {
+    private final ErrorCode errorCode;
+    private final Object[] args;
+
+    public ErrorException(ErrorCode errorCode, Object... args) {
+        super(errorCode.name());
+        this.errorCode = errorCode;
+        this.args = args;
+    }
+
+}

--- a/backend/src/main/java/com/back/back9/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/back/back9/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,66 @@
+package com.back.back9.global.exception;
+
+import com.back.back9.global.error.ErrorCode;
+import com.back.back9.global.error.ErrorException;
+import com.back.back9.global.problem.ProblemDetails;
+import jakarta.validation.ConstraintViolationException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.properties.bind.BindException;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Map;
+
+@RestControllerAdvice
+@RequiredArgsConstructor
+@Slf4j
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ErrorException.class)
+    public ResponseEntity<ProblemDetail> handleErrorException(ErrorException ex) {
+        ProblemDetail pd = ProblemDetails.of(ex.getErrorCode(), ex.getArgs());
+        return ResponseEntity
+                .status(ex.getErrorCode().getStatus()).body(pd);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ProblemDetail> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
+        var pd = ProblemDetails.of(ErrorCode.INVALID_REQUEST);
+        pd.setProperty("fieldErrors", ex.getBindingResult().getFieldErrors()
+                .stream()
+                .map(fe -> Map.of(
+                        "field", fe.getField(),
+                        "rejectedValue", fe.getRejectedValue(),
+                        "message", fe.getDefaultMessage()))
+                .toList());
+
+        return ResponseEntity
+                .status(ErrorCode.INVALID_REQUEST.getStatus())
+                .body(pd);
+    }
+
+    @ExceptionHandler({BindException.class, ConstraintViolationException.class,
+    HttpMessageNotReadableException.class})
+    public ResponseEntity<ProblemDetail> handleBindException(Exception ex) {
+        var pd = ProblemDetails.of(ErrorCode.INVALID_REQUEST, ex.getMessage());
+        return ResponseEntity
+                .status(ErrorCode.INVALID_REQUEST.getStatus())
+                .body(pd);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ProblemDetail> handleGeneralException(Exception ex) {
+        log.error("Unhandled exception occurred: {}", ex.getMessage(), ex);
+        var pd = ProblemDetails.of(ErrorCode.INTERNAL_ERROR, ex.getMessage());
+        return ResponseEntity
+                .status(ErrorCode.INTERNAL_ERROR.getStatus())
+                .body(pd);
+    }
+
+
+}

--- a/backend/src/main/java/com/back/back9/global/problem/ProblemDetails.java
+++ b/backend/src/main/java/com/back/back9/global/problem/ProblemDetails.java
@@ -1,0 +1,45 @@
+package com.back.back9.global.problem;
+
+import com.back.back9.global.error.ErrorCode;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.util.Map;
+
+public final class ProblemDetails {
+
+    private ProblemDetails() {}
+
+    public static ProblemDetail of(ErrorCode code, Object... args) {
+        String detail = args == null || args.length == 0
+                ? code.getDefaultDetail()
+                : String.format(code.getDefaultDetail(), args);
+
+
+        ProblemDetail pd = ProblemDetail.forStatus(code.getStatus());
+        pd.setTitle(code.name());
+        pd.setType(URI.create("about:blank"));
+        pd.setProperty("code", code.getCode());
+        pd.setProperty("timestamp", OffsetDateTime.now());
+        return pd;
+
+    }
+
+    public static ProblemDetail of(HttpStatus status, String title,
+                                   String detail,
+                                   String code,
+                                   Map<String, Object> properties) {
+        ProblemDetail pd = ProblemDetail.forStatusAndDetail(status, detail);
+        pd.setTitle(title);
+
+        if(code != null) pd.setProperty("code", code);
+        if(properties != null) {
+            properties.forEach(pd::setProperty);
+        }
+        pd.setProperty("timestamp", OffsetDateTime.now());
+
+        return pd;
+}
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -3,6 +3,9 @@ spring:
     name: back
   profiles:
     active: test
+  mvc:
+    problem_details:
+      enabled: true
   output:
     ansi:
       enabled: always

--- a/backend/src/test/java/com/back/back9/domain/wallet/controller/WalletControllerTest.java
+++ b/backend/src/test/java/com/back/back9/domain/wallet/controller/WalletControllerTest.java
@@ -1,0 +1,354 @@
+package com.back.back9.domain.wallet.controller;
+
+import com.back.back9.domain.wallet.dto.ChargePointsRequest;
+import com.back.back9.domain.wallet.entity.Wallet;
+import com.back.back9.domain.wallet.repository.WalletRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+@DisplayName("WalletController 통합 테스트")
+@Transactional
+public class WalletControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private WalletRepository walletRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        walletRepository.deleteAll();
+    }
+
+    @Nested
+    @DisplayName("지갑 잔액 조회 테스트")
+    class GetWalletBalanceTest {
+
+        @Test
+        @DisplayName("성공: 유효한 사용자 ID와 코인 ID로 잔액 조회")
+        void t1() throws Exception {
+            // 데이터 저장
+            int userId = 1;
+            int coinId = 1;
+            Wallet wallet = Wallet.builder()
+                    .userId(userId)
+                    .coinId(coinId)
+                    .address("0x123456789")
+                    .balance(new BigDecimal("1000.50"))
+                    .build();
+            walletRepository.save(wallet);
+
+            // 검증
+            mockMvc.perform(get("/api/wallets/users/{userId}/coins/{coinId}", userId, coinId))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.userId").value(userId))
+                    .andExpect(jsonPath("$.address").value("0x123456789"))
+                    .andExpect(jsonPath("$.balance").value(1000.50));
+        }
+
+        @Test
+        @DisplayName("성공: 잔액이 0인 경우")
+        void t2() throws Exception {
+            // 데이터 저장(0원)
+            int userId = 2;
+            int coinId = 1;
+            Wallet wallet = Wallet.builder()
+                    .userId(userId)
+                    .coinId(coinId)
+                    .address("0x987654321")
+                    .balance(BigDecimal.ZERO)
+                    .build();
+            walletRepository.save(wallet);
+
+            // 검증
+            mockMvc.perform(get("/api/wallets/users/{userId}/coins/{coinId}", userId, coinId))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.balance").value(0.0));
+        }
+
+        @Test
+        @DisplayName("실패: 존재하지 않는 사용자 ID")
+        void t3() throws Exception {
+            // userId와 coinId가 존재하지 않는 경우
+            int userId = 999;
+            int coinId = 1;
+
+            // 검증
+            mockMvc.perform(get("/api/wallets/users/{userId}/coins/{coinId}", userId, coinId))
+                    .andDo(print())
+                    .andExpect(status().isNotFound());
+        }
+
+        @Test
+        @DisplayName("실패: 잘못된 경로 파라미터 형식")
+        void t4() throws Exception {
+            // 잘못된 사용자 ID와 코인 ID
+            mockMvc.perform(get("/api/wallets/users/invalid/coins/invalid"))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+        }
+    }
+
+    @Nested
+    @DisplayName("포인트 충전 테스트")
+    class ChargePointsTest {
+
+        @Test
+        @DisplayName("성공: 유효한 충전 요청")
+        void t5() throws Exception {
+            // DB에 지갑 데이터 저장
+            int userId = 1;
+            int coinId = 1;
+            Wallet wallet = Wallet.builder()
+                    .userId(userId)
+                    .coinId(coinId)
+                    .address("0x123456789")
+                    .balance(new BigDecimal("1000.00"))
+                    .build();
+            walletRepository.save(wallet);
+
+            BigDecimal chargeAmount = new BigDecimal("500.00");
+            ChargePointsRequest request = new ChargePointsRequest(chargeAmount);
+
+            // 검증
+            mockMvc.perform(post("/api/wallets/users/{userId}/coins/{coinId}/charge", userId, coinId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.userId").value(userId))
+                    .andExpect(jsonPath("$.address").value("0x123456789"));
+        }
+
+        @Test
+        @DisplayName("실패: 음수 충전 금액")
+        void t6() throws Exception {
+            // DB에 지갑 데이터 저장
+            int userId = 1;
+            int coinId = 1;
+            Wallet wallet = Wallet.builder()
+                    .userId(userId)
+                    .coinId(coinId)
+                    .address("0x123456789")
+                    .balance(new BigDecimal("1000.00"))
+                    .build();
+            walletRepository.save(wallet);
+
+            ChargePointsRequest request = new ChargePointsRequest(new BigDecimal("-100.00"));
+
+            // 검증
+            mockMvc.perform(post("/api/wallets/users/{userId}/coins/{coinId}/charge", userId, coinId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("실패: null 충전 금액")
+        void t7() throws Exception {
+            // DB에 지갑 데이터 저장
+            int userId = 1;
+            int coinId = 1;
+            Wallet wallet = Wallet.builder()
+                    .userId(userId)
+                    .coinId(coinId)
+                    .address("0x123456789")
+                    .balance(new BigDecimal("1000.00"))
+                    .build();
+            walletRepository.save(wallet);
+
+            String requestBody = "{\"amount\": null}";
+
+            // 검증
+            mockMvc.perform(post("/api/wallets/users/{userId}/coins/{coinId}/charge", userId, coinId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestBody))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("실패: 빈 요청 본문")
+        void t8() throws Exception {
+            // DB에 지갑 데이터 저장
+            int userId = 1;
+            int coinId = 1;
+            Wallet wallet = Wallet.builder()
+                    .userId(userId)
+                    .coinId(coinId)
+                    .address("0x123456789")
+                    .balance(new BigDecimal("1000.00"))
+                    .build();
+            walletRepository.save(wallet);
+
+            // 검증
+            mockMvc.perform(post("/api/wallets/users/{userId}/coins/{coinId}/charge", userId, coinId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{}"))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("실패: 잘못된 JSON 형식")
+        void t9() throws Exception {
+            // User ID와 Coin ID 설정
+            int userId = 1;
+            int coinId = 1;
+
+            // 잘못된 요청 본문
+            mockMvc.perform(post("/api/wallets/users/{userId}/coins/{coinId}/charge", userId, coinId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"amount\": \"invalid\"}"))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("성공: 소수점 충전 금액")
+        void t10() throws Exception {
+            // DB에 지갑 데이터 저장
+            int userId = 1;
+            int coinId = 1;
+            Wallet wallet = Wallet.builder()
+                    .userId(userId)
+                    .coinId(coinId)
+                    .address("0x123456789")
+                    .balance(new BigDecimal("1000.00"))
+                    .build();
+            walletRepository.save(wallet);
+
+            BigDecimal chargeAmount = new BigDecimal("123.456");
+            ChargePointsRequest request = new ChargePointsRequest(chargeAmount);
+
+            // 검증
+            mockMvc.perform(post("/api/wallets/users/{userId}/coins/{coinId}/charge", userId, coinId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.balance").value(1123.456));
+        }
+
+        @Test
+        @DisplayName("실패: 존재하지 않는 지갑에 충전 시도")
+        void t11() throws Exception {
+            // DB에 지갑 데이터가 없는 경우
+            int userId = 999;
+            int coinId = 1;
+            ChargePointsRequest request = new ChargePointsRequest(new BigDecimal("100.00"));
+
+            // 검증
+            mockMvc.perform(post("/api/wallets/users/{userId}/coins/{coinId}/charge", userId, coinId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isNotFound());
+        }
+    }
+
+    @Nested
+    @DisplayName("통합 시나리오 테스트")
+    class IntegrationScenarioTest {
+
+        @Test
+        @DisplayName("시나리오: 지갑 생성 후 잔액 조회 및 포인트 충전")
+        void t12() throws Exception {
+            // DB에 지갑 데이터 저장
+            int userId = 1;
+            int coinId = 1;
+            Wallet wallet = Wallet.builder()
+                    .userId(userId)
+                    .coinId(coinId)
+                    .address("0x123456789")
+                    .balance(new BigDecimal("1000.00"))
+                    .build();
+            walletRepository.save(wallet);
+
+            // 초기 잔액 검증
+            mockMvc.perform(get("/api/wallets/users/{userId}/coins/{coinId}", userId, coinId))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.balance").value(1000.00));
+
+            // 포인트 충전
+            ChargePointsRequest request = new ChargePointsRequest(new BigDecimal("500.00"));
+            mockMvc.perform(post("/api/wallets/users/{userId}/coins/{coinId}/charge", userId, coinId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.userId").value(userId));
+
+            // 충전 후 잔액 검증
+            mockMvc.perform(get("/api/wallets/users/{userId}/coins/{coinId}", userId, coinId))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.balance").value(1500.00));
+        }
+
+        @Test
+        @DisplayName("시나리오: 여러 번 충전 테스트")
+        void t13() throws Exception {
+            // DB에 지갑 데이터 저장
+            int userId = 1;
+            int coinId = 1;
+            Wallet wallet = Wallet.builder()
+                    .userId(userId)
+                    .coinId(coinId)
+                    .address("0x123456789")
+                    .balance(new BigDecimal("100.00"))
+                    .build();
+            walletRepository.save(wallet);
+
+            // 첫 번째 충전
+            ChargePointsRequest firstCharge = new ChargePointsRequest(new BigDecimal("200.00"));
+            mockMvc.perform(post("/api/wallets/users/{userId}/coins/{coinId}/charge", userId, coinId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(firstCharge)))
+                    .andExpect(status().isOk());
+
+            // 두 번째 충전
+            ChargePointsRequest secondCharge = new ChargePointsRequest(new BigDecimal("150.00"));
+            mockMvc.perform(post("/api/wallets/users/{userId}/coins/{coinId}/charge", userId, coinId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(secondCharge)))
+                    .andExpect(status().isOk());
+
+            // 최종 잔액 확인
+            mockMvc.perform(get("/api/wallets/users/{userId}/coins/{coinId}", userId, coinId))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.userId").value(userId));
+            // 잔액 검증
+            mockMvc.perform(get("/api/wallets/users/{userId}/coins/{coinId}", userId, coinId))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.balance").value(450.00)); // 100 + 200 + 150
+        }
+    }
+}


### PR DESCRIPTION
## 기능 설명
<!-- 어떤 기능(또는 버그 수정)인지 간단히 서술 -->

- 지갑 잔액 확인은 /api/wallet/user/{userid}/coin/{coinid}
- 지갑 잔액 충전은 /api/wallet/user/{userid}/coin/{coinid}/charge 로 한다
- 매 충전, 확인마다 서비스에서 트랜젝션으로 묶음
- 에러는 Problem형식으로 응답(에러코드 모음)



## 구현 방법
<!-- 핵심 로직, 사용한 기술 스택, 주요 변경 사항 등을 요약 -->

- TDD방식으로 했고, ProblemDetail을 이용해서 에러코드 핸들링
- 엔티티에서 충전 메서드 구현
- 서비스에서는 DB에 접근 및 응답 Dto로 반환
- Controller에서 pathvariable로 파라미터를 받음(후에 RequestBody로 변경 가능, 현재 임시임)
- 추가적인 참고 사항(없으면 비워도됨)

## 추가적인 참고 사항
<!-- 스크린샷, 링크, 테스트 방법 등 (없으면 비워두세요) -->

- 필요한 에러코드가 있을시, Global의 Problem에 들어가서 해당 형식에 맞게 한줄만 추가해서 사용하면 됨
- 사용방법은 코드에 주석 및 서비스 라인 참고
